### PR TITLE
Bug/saving park

### DIFF
--- a/controllers/api/savedparks-routes.js
+++ b/controllers/api/savedparks-routes.js
@@ -42,7 +42,7 @@ router.post("/", (req, res) => {
   // this shouldnt get triggered on the website as it should flip the "save" button to a "saved" button, but better safe than sorry
   Saved_Parks.findAll({
     Attributes: [[sequelize.fn('DISTINCT', sequelize.col('user_id')), 'user_id'], 'park_id'],
-    group: ['user_id', 'park_id'],
+    // group: ['user_id', 'park_id'],
     where: {
       user_id: req.body.user_id,
       park_id: req.body.park_id

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -305,9 +305,10 @@ form button:hover {
 
 .modal-saved {
   padding-top: 10px;
-  width: 100%;
   font-weight: 400;
   font-size: 20px;
+  cursor: pointer;
+  width: fit-content;
 }
 
 .close-modal {
@@ -508,6 +509,7 @@ form button:hover {
 .saved {
   font-weight: 600;
   font-size: 15px;
+  width: fit-content;
 }
 
 .saved::before, .modal-saved::before {


### PR DESCRIPTION
Getting the error when trying to save: 
    _sqlState: '42000',
    sqlMessage: "Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 
    'parktime_db.saved_parks.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible 
    with sql_mode=only_full_group_by",
    sql: "SELECT `id`, `user_id`, `park_id` FROM `saved_parks` AS `saved_parks` WHERE `saved_parks`.`user_id` = '3' 
    AND `saved_parks`.`park_id` = '384' GROUP BY `user_id`, `park_id`;",_

I'm not sure that the group by clause is necessary, but could be wrong. 
Found this article about the error that I think it helpful: https://www.aaronsaray.com/2019/expression-1-not-in-group-by and the top answer on this post is also helpful: https://stackoverflow.com/questions/38705315/mysql-error-select-list-is-not-in-group-by-clause
I tested with this clause commented out and the saving worked as expected.
**also fixed styling on the Save/Saved text so that the clickable portion is contained to the text only 

