### PR TITLE
fixed modal close, added password req text, removed console logs

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -708,6 +708,15 @@ textarea.comment-body {
   cursor: pointer;
 }
 
+#password-help {
+  padding: 0px 0px 10px 0px;
+  width: 100%;
+  text-align: center;
+  font-size: 15px;
+  color: #c7c7c7;
+  font-style: italic;
+}
+
 @media screen and (max-width: 1024px) {
   form {
     grid-template-columns: repeat(13, 1fr);

--- a/public/assets/js/modal.js
+++ b/public/assets/js/modal.js
@@ -1,3 +1,13 @@
+
+// fires when we click outside of a modal
+$('.park-result-modal').click((event) => { 
+  event.stopPropagation();
+  let id = $(event.target).attr('id');
+  if (id != undefined) {
+    closeModal(id.split('-')[0]);
+  }
+}); 
+
 function openModal(parkCode) {
   document.getElementById(parkCode + "-modal").style.display = "flex";
 

--- a/public/assets/js/save-system.js
+++ b/public/assets/js/save-system.js
@@ -13,8 +13,6 @@ $(".saved").on('click', function (event) {
 
 saveOrDelete = (event) => {
 
-  console.log(resultsPage.attr("user_id"));
-  console.log($(event.target).attr("park_id"));
   if (resultsPage.attr("user_id") != 0) {
 
     if ($(event.target).text() === "Save") {
@@ -32,7 +30,6 @@ saveOrDelete = (event) => {
         .then(function (res) {
 
           if ($(event.target).hasClass("modal-saved")) { // if we click on the save button via the modal...
-            console.log("clicked on modal save");
             $(event.target).text("Saved"); // set modal to saved
             let parks = $(".saved").map(function () {
               if ($(this).attr("park_id") === $(event.target).attr("park_id")) {
@@ -43,7 +40,6 @@ saveOrDelete = (event) => {
           }
           else {
             if ($(event.target).hasClass("saved")) { // if we click on the save button via the park results
-              console.log("clicked on results save");
               $(event.target).text("Saved"); // set park results to saved
               let modalParks = $(".modal-saved").map(function () {
                 if ($(this).attr("park_id") === $(event.target).attr("park_id")) {
@@ -81,7 +77,6 @@ saveOrDelete = (event) => {
           }
           else {
             if ($(event.target).hasClass("saved")) { // if we click on the save button via the park results
-              console.log("clicked on results save");
               $(event.target).text("Save"); // set park results to save
               let modalParks = $(".modal-saved").map(function () {
                 if ($(this).attr("park_id") === $(event.target).attr("park_id")) {

--- a/views/login.handlebars
+++ b/views/login.handlebars
@@ -29,6 +29,7 @@
 
         <label for="password-signup">Password</label>
         <input type="password" id="password-signup" />
+        <p id="password-help">password has to be between 8 and 10 characters long</p>
 
         <button type="submit">Sign Up!</button>
 


### PR DESCRIPTION
now you can click outside the modal to close it, and I added some password requirement text to the sign page, as it looked like a bug before when you got the invalid password req error. I also removed some console.logs